### PR TITLE
update testcontainers and default cypress image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -324,6 +324,10 @@ The `CYPRESS_RECORD_KEY` environment variable needs to be set for this to work.
 |===
 |Testcontainers-cypress |Testcontainers | Cypress
 
+|https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.3.0[1.3.0]
+|https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.2[1.15.2]
+|https://docs.cypress.io/guides/references/changelog.html#6-7-1[6.7.1]
+
 |https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.2.1[1.2.1]
 |https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1[1.15.1]
 |https://docs.cypress.io/guides/references/changelog.html#5-6-0[5.6.0]

--- a/README.adoc
+++ b/README.adoc
@@ -326,7 +326,7 @@ The `CYPRESS_RECORD_KEY` environment variable needs to be set for this to work.
 
 |https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.3.0[1.3.0]
 |https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.2[1.15.2]
-|https://docs.cypress.io/guides/references/changelog.html#6-7-1[6.7.1]
+|https://docs.cypress.io/guides/references/changelog.html#6-7-1[6.8.0]
 
 |https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.2.1[1.2.1]
 |https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1[1.15.1]

--- a/README.adoc
+++ b/README.adoc
@@ -326,7 +326,7 @@ The `CYPRESS_RECORD_KEY` environment variable needs to be set for this to work.
 
 |https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.3.0[1.3.0]
 |https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.2[1.15.2]
-|https://docs.cypress.io/guides/references/changelog.html#6-7-1[6.8.0]
+|https://docs.cypress.io/guides/references/changelog.html#6-8-0[6.8.0]
 
 |https://github.com/wimdeblauwe/testcontainers-cypress/releases/tag/testcontainers-cypress-1.2.1[1.2.1]
 |https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1[1.15.1]

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[${java.version}, 12]</version>
+                            <version>[${java.version}, 1.9]</version>
                         </requireJavaVersion>
                     </rules>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <java.version>1.8</java.version>
 
         <!-- Dependencies -->
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <slf4j-api.version>1.7.29</slf4j-api.version>
         <jackson.version>2.10.1</jackson.version>
@@ -144,7 +144,7 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[${java.version}, 1.9]</version>
+                            <version>[${java.version}, 12]</version>
                         </requireJavaVersion>
                     </rules>
                 </configuration>

--- a/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
+++ b/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
@@ -24,7 +24,7 @@ public class CypressContainer extends GenericContainer<CypressContainer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CypressContainer.class);
 
     private static final String CYPRESS_IMAGE = "cypress/included";
-    private static final String CYPRESS_VERSION = "6.7.1";
+    private static final String CYPRESS_VERSION = "6.8.0";
 
     private static final int DEFAULT_PORT = 8080;
     private static final String DEFAULT_BASE_URL = "http://host.testcontainers.internal";

--- a/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
+++ b/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
@@ -24,7 +24,7 @@ public class CypressContainer extends GenericContainer<CypressContainer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CypressContainer.class);
 
     private static final String CYPRESS_IMAGE = "cypress/included";
-    private static final String CYPRESS_VERSION = "5.6.0";
+    private static final String CYPRESS_VERSION = "6.7.1";
 
     private static final int DEFAULT_PORT = 8080;
     private static final String DEFAULT_BASE_URL = "http://host.testcontainers.internal";

--- a/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
@@ -19,7 +19,7 @@ class CypressContainerTest {
     void testDefaultDockerImage() {
         CypressContainer container = new CypressContainer();
         container.configure();
-        assertThat(container.getDockerImageName()).isEqualTo("cypress/included:6.7.1");
+        assertThat(container.getDockerImageName()).isEqualTo("cypress/included:6.8.0");
         assertThat(container.getWorkingDirectory()).isEqualTo("/e2e");
     }
 

--- a/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
@@ -19,7 +19,7 @@ class CypressContainerTest {
     void testDefaultDockerImage() {
         CypressContainer container = new CypressContainer();
         container.configure();
-        assertThat(container.getDockerImageName()).isEqualTo("cypress/included:5.6.0");
+        assertThat(container.getDockerImageName()).isEqualTo("cypress/included:6.7.1");
         assertThat(container.getWorkingDirectory()).isEqualTo("/e2e");
     }
 


### PR DESCRIPTION
This PR updates testcontainers to `1.15..2` and upgrades the default cypress image to `6.7.1`. Furthermore the java version range has been extended to be able to build with java 11 without enforcer error.