### PR TITLE
Pass failed tests' cause to be able to print in the test output.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,7 +220,13 @@ public class CypressEndToEndTests {
     private void createContainerFromSuite(List<DynamicContainer> dynamicContainers, CypressTestSuite suite) {
         List<DynamicTest> dynamicTests = new ArrayList<>();
         for (CypressTest test : suite.getTests()) {
-            dynamicTests.add(DynamicTest.dynamicTest(test.getDescription(), () -> assertTrue(test.isSuccess())));
+            dynamicTests.add(DynamicTest.dynamicTest(test.getDescription(), () -> {
+                if (!test.isSuccess()) {
+                    LOGGER.error(test.getErrorMessage());
+                    LOGGER.error(test.getStackTrace());
+                }
+                assertTrue(test.isSuccess());
+            }));
         }
         dynamicContainers.add(DynamicContainer.dynamicContainer(suite.getTitle(), dynamicTests));
     }

--- a/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressTest.java
+++ b/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressTest.java
@@ -3,10 +3,19 @@ package io.github.wimdeblauwe.testcontainers.cypress;
 public class CypressTest {
     private String description;
     private boolean success;
+    private String errorMessage;
+    private String stackTrace;
 
     public CypressTest(String description, boolean success) {
         this.description = description;
         this.success = success;
+    }
+
+    public CypressTest(String description, boolean success, String errorMessage, String stackTrace) {
+        this.description = description;
+        this.success = success;
+        this.errorMessage = errorMessage;
+        this.stackTrace = stackTrace;
     }
 
     public String getDescription() {
@@ -15,5 +24,21 @@ public class CypressTest {
 
     public boolean isSuccess() {
         return success;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/MochawesomeGatherTestResultsStrategy.java
+++ b/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/MochawesomeGatherTestResultsStrategy.java
@@ -84,7 +84,10 @@ public class MochawesomeGatherTestResultsStrategy implements GatherTestResultsSt
                     CypressTestSuite cypressTestSuite = new CypressTestSuite(suite.getTitle());
                     List<SuiteTest> tests = suite.getTests();
                     for (SuiteTest test : tests) {
-                        cypressTestSuite.add(new CypressTest(test.getTitle(), !test.isFail()));
+                        CypressTest cypressTest = test.isFail()
+                                ? new CypressTest(test.getTitle(), false, test.getErr().getMessage(), test.getErr().getEstack())
+                                : new CypressTest(test.getTitle(), true);
+                        cypressTestSuite.add(cypressTest);
                     }
 
                     cypressTestSuites.add(cypressTestSuite);
@@ -164,6 +167,7 @@ public class MochawesomeGatherTestResultsStrategy implements GatherTestResultsSt
         private static class SuiteTest {
             private String title;
             private boolean fail;
+            private SuiteTestError err;
 
             public String getTitle() {
                 return title;
@@ -179,6 +183,36 @@ public class MochawesomeGatherTestResultsStrategy implements GatherTestResultsSt
 
             public void setFail(boolean fail) {
                 this.fail = fail;
+            }
+
+            public SuiteTestError getErr() {
+                return err;
+            }
+
+            public void setErr(SuiteTestError err) {
+                this.err = err;
+            }
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        private static class SuiteTestError {
+            private String message;
+            private String estack;
+
+            public String getMessage() {
+                return message;
+            }
+
+            public void setMessage(String message) {
+                this.message = message;
+            }
+
+            public String getEstack() {
+                return estack;
+            }
+
+            public void setEstack(String estack) {
+                this.estack = estack;
             }
         }
     }

--- a/src/test/resources/io/github/wimdeblauwe/testcontainers/cypress/mochawesome/mochawesome_009.json
+++ b/src/test/resources/io/github/wimdeblauwe/testcontainers/cypress/mochawesome/mochawesome_009.json
@@ -1,0 +1,110 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 1,
+    "passes": 0,
+    "pending": 0,
+    "failures": 1,
+    "start": "2021-11-24T08:58:07.097Z",
+    "end": "2021-11-24T08:58:35.605Z",
+    "duration": 28508,
+    "testsRegistered": 1,
+    "passPercent": 0,
+    "pendingPercent": 0,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false
+  },
+  "results": [
+    {
+      "uuid": "9e15ddcc-49c2-433b-bc15-0547d428f3d1",
+      "title": "",
+      "fullFile": "cypress/integration/firstFile.js",
+      "file": "cypress/integration/firstFile.js",
+      "beforeHooks": [],
+      "afterHooks": [],
+      "tests": [],
+      "suites": [
+        {
+          "uuid": "916db3c4-4819-458c-8708-7c5fd1f3ee5e",
+          "title": "First File",
+          "fullFile": "",
+          "file": "",
+          "beforeHooks": [],
+          "afterHooks": [],
+          "tests": [
+            {
+              "title": "Log in",
+              "fullTitle": "First File Log in",
+              "timedOut": null,
+              "duration": 7143,
+              "state": "failed",
+              "speed": null,
+              "pass": false,
+              "fail": true,
+              "pending": false,
+              "context": null,
+              "code": "cy.get('.welcome-message').should('contain', 'Please start search using form to the left.');",
+              "err": {
+                "message": "AssertionError: Timed out retrying after 4000ms: Expected to find element: `.welcome-message`, but never found it.",
+                "estack": "AssertionError: Timed out retrying after 4000ms: Expected to find element: `.welcome-message`, but never found it.\n    at Context.eval (http://localhost/__cypress/tests?p=cypress/integration/firstFile.js:170:32)",
+                "diff": null
+              },
+              "uuid": "d6b462ef-3bab-43f9-a5f3-d7f9942b6540",
+              "parentUUID": "916db3c4-4819-458c-8708-7c5fd1f3ee5e",
+              "isHook": false,
+              "skipped": false
+            }
+          ],
+          "suites": [],
+          "passes": [],
+          "failures": [
+            "d6b462ef-3bab-43f9-a5f3-d7f9942b6540"
+          ],
+          "pending": [],
+          "skipped": [],
+          "duration": 7143,
+          "root": false,
+          "rootEmpty": false,
+          "_timeout": 2000
+        }
+      ],
+      "passes": [],
+      "failures": [],
+      "pending": [],
+      "skipped": [],
+      "duration": 0,
+      "root": true,
+      "rootEmpty": true,
+      "_timeout": 2000
+    }
+  ],
+  "meta": {
+    "mocha": {
+      "version": "7.0.1"
+    },
+    "mochawesome": {
+      "options": {
+        "quiet": false,
+        "reportFilename": "mochawesome",
+        "saveHtml": false,
+        "saveJson": true,
+        "consoleReporter": "spec",
+        "useInlineDiffs": false,
+        "code": true
+      },
+      "version": "7.0.1"
+    },
+    "marge": {
+      "options": {
+        "id": "default",
+        "reportDir": "cypress/reports/mochawesome",
+        "overwrite": true,
+        "html": false,
+        "json": true
+      },
+      "version": "6.0.1"
+    }
+  }
+}


### PR DESCRIPTION
Added Mochawesome Gather Strategy extension to pass failed tests' error message.
Added example how to use for output.
Covered with test.