### PR TITLE
Update build status badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Cypress Testcontainer
 :toc: macro
 
-image:https://travis-ci.org/wimdeblauwe/testcontainers-cypress.svg?branch=master["Build Status", link="https://travis-ci.org/wimdeblauwe/testcontainers-cypress"]
+image:https://img.shields.io/github/workflow/status/wimdeblauwe/testcontainers-cypress/Build["Build Status", link="https://github.com/wimdeblauwe/testcontainers-cypress/actions/workflows/build.yml"]
 image:https://sonarcloud.io/api/project_badges/measure?project=io.github.wimdeblauwe%3Atestcontainers-cypress&metric=coverage["Coverage", link="https://sonarcloud.io/dashboard?id=io.github.wimdeblauwe%3Atestcontainers-cypress"]
 image:https://maven-badges.herokuapp.com/maven-central/io.github.wimdeblauwe/testcontainers-cypress/badge.svg["Maven Central", link="https://search.maven.org/search?q=a:testcontainers-cypress"]
 


### PR DESCRIPTION
This PR updates build status badge in README. 
Before change:
- README has build status badge from Travis. This project no longer uses Travis. 
<img width="366" alt="Zrzut ekranu 2022-10-5 o 19 23 00" src="https://user-images.githubusercontent.com/1526000/194122780-b56329f1-c9e7-4ac4-9f74-428613ad5706.png">


After change:
- README has build status badge from Github Action (workflow) and link to Build workflow. 
- I used badge from https://shields.io, because it has look consistent with other badges in README. Badge from Github (https://github.com/wimdeblauwe/testcontainers-cypress/actions/workflows/build.yml/badge.svg) has different look ![](https://github.com/wimdeblauwe/testcontainers-cypress/actions/workflows/build.yml/badge.svg)
<img width="398" alt="Zrzut ekranu 2022-10-5 o 19 22 53" src="https://user-images.githubusercontent.com/1526000/194122870-8f7db7cc-7d46-40a7-b874-c7925d2b0612.png">
