### PR TITLE
Add option for npm install additional args

### DIFF
--- a/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
+++ b/src/main/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainer.java
@@ -48,6 +48,7 @@ public class CypressContainer extends GenericContainer<CypressContainer> {
     private Duration maximumTotalTestDuration = DEFAULT_MAX_TOTAL_TEST_DURATION;
     private GatherTestResultsStrategy gatherTestResultsStrategy = DEFAULT_GATHER_TEST_RESULTS_STRATEGY;
     private boolean autoCleanReports = DEFAULT_AUTO_CLEAN_REPORTS;
+    private String npmRunArguments = "--loglevel silent";
 
     public CypressContainer() {
         this(CYPRESS_IMAGE + ":" + CYPRESS_VERSION);
@@ -255,6 +256,18 @@ public class CypressContainer extends GenericContainer<CypressContainer> {
     }
 
     /**
+    * Set additional run arguments for npm install.
+    * <br>
+    * The default is <code>--loglevel silent</code>
+    *
+    * @param args additional arguments
+    */
+    public CypressContainer withNpmRunArguments(String args) {
+        this.npmRunArguments = args;
+        return self();
+    }
+
+    /**
      * Waits until the Cypress tests are done and returns the results of the tests.
      *
      * @return the Cypress test results
@@ -315,7 +328,7 @@ public class CypressContainer extends GenericContainer<CypressContainer> {
                    .append(reportsPathInContainer)
                    .append(" && ");
         }
-        builder.append("npm install && ");
+        builder.append("npm install " + npmRunArguments + " && ");
         builder.append("cypress run ")
                .append(buildCypressRunArguments());
         return builder.toString();

--- a/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/testcontainers/cypress/CypressContainerTest.java
@@ -92,7 +92,23 @@ class CypressContainerTest {
         CreateContainerCmdModifier createContainerCmdModifier = createContainerCmdModifiers.iterator().next();
         CreateContainerCmd cmd = mock(CreateContainerCmd.class);
         createContainerCmdModifier.modify(cmd);
-        verify(cmd).withEntrypoint("bash", "-c", "npm install && cypress run --headless --browser firefox");
+        verify(cmd).withEntrypoint("bash", "-c", "npm install --loglevel silent && cypress run --headless --browser firefox");
+    }
+
+    @Test
+    void testNpmRunArguments() {
+        Set<CreateContainerCmdModifier> createContainerCmdModifiers;
+        try (CypressContainer container = new CypressContainer()
+                .withBrowser("firefox")
+                .withNpmRunArugments("--loglevel verbose")) {
+            container.configure();
+            createContainerCmdModifiers = container.getCreateContainerCmdModifiers();
+        }
+        assertThat(createContainerCmdModifiers).hasSize(1);
+        CreateContainerCmdModifier createContainerCmdModifier = createContainerCmdModifiers.iterator().next();
+        CreateContainerCmd cmd = mock(CreateContainerCmd.class);
+        createContainerCmdModifier.modify(cmd);
+        verify(cmd).withEntrypoint("bash", "-c", "npm install --loglevel verbose && cypress run --headless --browser firefox");
     }
 
     @Test
@@ -123,7 +139,7 @@ class CypressContainerTest {
         createContainerCmdModifier.modify(cmd);
         verify(cmd).withEntrypoint("bash",
                                    "-c",
-                                   "rm -rf cypress/reports/mochawesome && npm install && cypress run --headless");
+                                   "rm -rf cypress/reports/mochawesome && npm install --loglevel silent && cypress run --headless");
     }
 
     @Test
@@ -140,7 +156,7 @@ class CypressContainerTest {
         CreateContainerCmdModifier createContainerCmdModifier = createContainerCmdModifiers.iterator().next();
         CreateContainerCmd cmd = mock(CreateContainerCmd.class);
         createContainerCmdModifier.modify(cmd);
-        verify(cmd).withEntrypoint("bash", "-c", "npm install && cypress run --headless --spec \"cypress/integration/todos.spec.js\"");
+        verify(cmd).withEntrypoint("bash", "-c", "npm install --loglevel silent && cypress run --headless --spec \"cypress/integration/todos.spec.js\"");
     }
 
     @Test
@@ -173,7 +189,7 @@ class CypressContainerTest {
         createContainerCmdModifier.modify(cmd);
         verify(cmd).withEntrypoint("bash",
                                    "-c",
-                                   "rm -rf github/wimdeblauwe && npm install && cypress run --headless");
+                                   "rm -rf github/wimdeblauwe && npm install --loglevel silent && cypress run --headless");
     }
 
     @Test
@@ -204,7 +220,7 @@ class CypressContainerTest {
         CreateContainerCmdModifier createContainerCmdModifier = createContainerCmdModifiers.iterator().next();
         CreateContainerCmd cmd = mock(CreateContainerCmd.class);
         createContainerCmdModifier.modify(cmd);
-        verify(cmd).withEntrypoint("bash", "-c", "npm install && cypress run --headless --record");
+        verify(cmd).withEntrypoint("bash", "-c", "npm install --loglevel silent && cypress run --headless --record");
     }
 
     @Test
@@ -222,7 +238,7 @@ class CypressContainerTest {
         CreateContainerCmdModifier createContainerCmdModifier = createContainerCmdModifiers.iterator().next();
         CreateContainerCmd cmd = mock(CreateContainerCmd.class);
         createContainerCmdModifier.modify(cmd);
-        verify(cmd).withEntrypoint("bash", "-c", "npm install && cypress run --headless --record --key " + recordKey);
+        verify(cmd).withEntrypoint("bash", "-c", "npm install --loglevel silent && cypress run --headless --record --key " + recordKey);
     }
 
 }


### PR DESCRIPTION
I recently had the problem, that on CI my npm was not able to install anything due to wrong settings. I had to override some methods to add a loglevel to the npm install, to be able to see what was acutually happening. In this PR i added a default loglevel and the option to override/add other parameters directly to the npm install command.