### PR TITLE
Update readme file regarding `cypress` version consistency :memo:

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ The goal of this project is to make it easy to start https://www.cypress.io/[Cyp
 
 . Create `src/test/e2e` directory in your project.
 . Run `npm init` in that directory. This will generate a `package.json` file.
-. Run `npm install cypress --save-dev` to install Cypress as a development dependency.
+. Run `npm install cypress@13.14.2 --save-dev` to install Cypress as a development dependency. You can also use a different version of Cypress, just make sure that you provide the same version in the `CypressContainer` constructor to avoid compatibility issues.
 . Run `npx cypress open` to start the Cypress application. It will notice that this is the first startup and add some example tests.
 . Run `npm install cypress-multi-reporters mocha mochawesome --save-dev` to install Mochawesome as a test reporter. Testcontainers-cypress will
 use that to parse the results of the Cypress tests.


### PR DESCRIPTION
I suggest informing about cypress version mismatch hazards (experienced that myself today). 
Keeping synced versions might be achieved by either:

- specifying the cypress version used locally (directly via npm), *or*
- specifying the cypress image in `CypressContainer` constructor

so I've added appropriate note proposal to the readme file